### PR TITLE
Adding code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-# Ignore Gradle project-specific cache directory
-.gradle
+#OSX
+.DS_Store
 
-# Ignore Gradle build output directory
-build
-
-.project
-
+#IDEs
 .idea
 .vscode
+
+# Java
+.gradle
+bin
+build
+.classpath
+.project
+*.iml
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ subprojects {
     version '1.0.0'
 
     apply plugin: 'java'
+    apply plugin: 'jacoco'
+
+    //automatically run the code coverage report. Generated report at domain/build/reports/jacoco/test/html/index.html
+    test.finalizedBy jacocoTestReport
 
     sourceCompatibility = 1.11
 


### PR DESCRIPTION
Add JaCoCo (Java Code Coverage tool) to produce an HTML code coverage report at build time.
Automatically execute code coverage any time a test is run.